### PR TITLE
cgroup.cgroup: Merge autotest and virttest cgroup_utils library

### DIFF
--- a/cgroup/cgroup.py
+++ b/cgroup/cgroup.py
@@ -12,7 +12,13 @@ from subprocess import Popen
 
 from autotest.client import test, utils
 from autotest.client.shared import error
-from autotest.client.cgroup_utils import Cgroup, CgroupModules, get_load_per_cpu
+try:
+    from autotest.client.shared.utils_cgroup import Cgroup, CgroupModules
+    from autotest.client.shared.utils_cgroup import get_load_per_cpu
+except ImportError:
+    # TODO: Obsoleted path used prior autotest-0.15.2
+    from autotest.client.cgroup_utils import Cgroup, CgroupModules
+    from autotest.client.cgroup_utils import get_load_per_cpu
 
 
 class cgroup(test.test):


### PR DESCRIPTION
Hi guys,

from the discussion about cgroup_utils I created those pull requests, which should merge `cgroup_utils`/`utils_cgroup` libraries into single file.

Kind regards,
Lukáš Doktor
