### PR TITLE
cgroup: add version after first test

### DIFF
--- a/cgroup/cgroup.py
+++ b/cgroup/cgroup.py
@@ -80,6 +80,7 @@ class cgroup(test.test):
         self.modules = CgroupModules()
         if (self.modules.init(_modules) <= 0):
             raise error.TestFail('Can\'t mount any cgroup modules')
+        self.version += 1
 
     def cleanup(self):
         """ Cleanup """


### PR DESCRIPTION
Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com

For version always be 1, so after first execute, the second execute will fail, becaus setup() won't be executed again.
I think it's not convenient for tester.So add version in somewhere(setup() or run_once()) can make test run several
 times.
