### PR TITLE
cgroup.cgroup: Change setup to initialize

### DIFF
--- a/cgroup/cgroup.py
+++ b/cgroup/cgroup.py
@@ -67,9 +67,10 @@ class cgroup(test.test):
             logging.error('Some subtests failed (%s)', err[:-2])
             raise error.TestFail('Some subtests failed (%s)' % err[:-2])
 
-    def setup(self):
+    def initialize(self):
         """
-        Setup
+        Test initialization, Init and prepares listed cgroups for use. Not all
+        of them have to pass the initialization.
         """
         logging.debug('Setting up cgroups modules')
 


### PR DESCRIPTION
Setup is called only once to unzip/compile projects. Cgroups needs
to be initialized each time it's executed so it shoule use
initialize() instead.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
