### PR TITLE
cgroup_test: Make user can run part of test cases

### DIFF
--- a/cgroup_tests/cgroup_tests.py
+++ b/cgroup_tests/cgroup_tests.py
@@ -1,12 +1,5 @@
-import logging, sys
 from autotest.client import test
-from autotest.client.shared import error, utils, utils_cgroup
-try:
-    import device_rate_test
-    import memory_migrate_test
-    # TODO other sub systems test
-except ImportError:
-    raise error.TestError("Cgroup test module doesn't exist!")
+from autotest.client.shared import error, utils_cgroup
 
 class cgroup_tests(test.test):
     """
@@ -14,40 +7,20 @@ class cgroup_tests(test.test):
     """
     version = 1
     _cgroup_dir = "/cgroup"
-    _test_result = True
 
 
-    def run_once(self):
+    def run_once(self, item=""):
         """
         Test several subsystems
         """
-        fail_detail = []
+        if not item:
+            raise error.TestNAError('No test item provided')
+        # Check if 'item'.py(device_rate_test.py, etc.) exists or not
         try:
-            logging.info("---< 'device rate test' START >---")
-            self.device_rate_test()
-            logging.info("---< 'device rate test' PASSED >---")
-        except Exception:
-            logging.info("---< 'device rate test' FAILED >---")
-            detail = utils.etraceback("device rate", sys.exc_info())
-            logging.error("Failure details:\n%s", detail)
-            fail_detail.append(detail)
-            self._test_result = False
-
-        try:
-            logging.info("---< 'memory migrate test' START >---")
-            self.memory_migrate_test()
-            logging.info("---< 'memory migrate test' PASSED >---")
-        except Exception:
-            logging.info("---< 'memory migrate test' FAILED >---")
-            detail = utils.etraceback("memory migrate", sys.exc_info())
-            logging.error("Failure details:\n%s", detail)
-            fail_detail.append(detail)
-            self._test_result = False
-
-        # TODO other sub systems test
-        if not self._test_result:
-            raise error.TestFail("There are fail test cases:\n%s" %
-                                 "\n".join(fail_detail))
+            mod = __import__(item)
+        except ImportError:
+            raise error.TestNAError("%s module doesn't exist!" % item)
+        mod.execute(self)
 
 
     def initialize(self):
@@ -58,21 +31,5 @@ class cgroup_tests(test.test):
             utils_cgroup.all_cgroup_delete()
         except Exception:
             raise error.TestNAError("'cgclear' command failed. "
-                                    "Do you have libcgroup-tool installed?")
-
-
-    def device_rate_test(self):
-        """
-        Test file create rate in desired device with cgroup
-        """
-        device_test = device_rate_test.DeviceRate(self._cgroup_dir)
-        device_test.test()
-
-
-    def memory_migrate_test(self):
-        """
-        Test file create rate in desired device with cgroup
-        """
-        memory_test = memory_migrate_test.MemoryMigrate(self._cgroup_dir,
-                                                        self.tmpdir)
-        memory_test.test()
+                                    "Some subsystems are busy or "
+                                    "you don't have libcgroup-tool installed!")

--- a/cgroup_tests/control
+++ b/cgroup_tests/control
@@ -8,4 +8,11 @@ TEST_TYPE = "client"
 DOC = """
 This test checks basic functionality of cgroups
 """
-job.run_test('cgroup_tests')
+import os
+os.environ['LANG'] = 'en_US.UTF-8'
+cgroup_test_dir = os.path.join(os.environ['AUTODIR'],'tests/cgroup_tests')
+sys.path.insert(0, cgroup_test_dir)
+test_cfg = os.path.join(cgroup_test_dir, 'test.cfg')
+test_case_list = [_.strip() for _ in open(test_cfg)]
+for item in test_case_list:
+    job.run_test('cgroup_tests', item=item, subdir_tag=item)

--- a/cgroup_tests/device_rate_test.py
+++ b/cgroup_tests/device_rate_test.py
@@ -120,3 +120,15 @@ class DeviceRate(object):
             if os.path.exists(tmp_file):
                 os.remove(tmp_file)
             utils_cgroup.cgconfig_restart()
+
+
+def execute(cgroup_cls):
+    """
+    Execute device test.
+
+    @param: cgroup_cls: Cgroup class
+    """
+    if cgroup_cls is None:
+        raise error.TestNAError("Got a none cgroup class")
+    device_test = DeviceRate(cgroup_cls._cgroup_dir)
+    device_test.test()

--- a/cgroup_tests/memory_migrate_test.py
+++ b/cgroup_tests/memory_migrate_test.py
@@ -144,3 +144,15 @@ int main(void) {
             # Recover environment
             os.kill(pid, signal.SIGUSR1)
             utils_cgroup.cgconfig_restart()
+
+
+def execute(cgroup_cls):
+    """
+    Execute memory test.
+
+    @param: cgroup_cls: Cgroup class
+    """
+    if cgroup_cls is None:
+        raise error.TestNAError("Got a none cgroup class")
+    memory_test = MemoryMigrate(cgroup_cls._cgroup_dir, cgroup_cls.tmpdir)
+    memory_test.test()

--- a/cgroup_tests/test.cfg
+++ b/cgroup_tests/test.cfg
@@ -1,0 +1,2 @@
+device_rate_test
+memory_migrate_test


### PR DESCRIPTION
1.test.cfg can desire which test case you want to run.
2.Defaultly test.cfg contains all the testcases, you  can modify its detail to run different case.
3.test-example.cfg contains all the testcases, you  can get every testcase name.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
