### PR TITLE
.travis.yml: Fix PPA URL location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ virtualenv:
     system_site_packages: true
 
 before_script:
-    - echo "deb http://ppa.launchpad.net/lmr/autotest/ubuntu saucy main" | sudo tee -a /etc/apt/sources.list
+    - echo "deb http://ppa.launchpad.net/lmr/autotest/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
     - sudo apt-get update -q
     - sudo apt-get -y --force-yes install autotest
 


### PR DESCRIPTION
Fix the broken Travis build to point the PPA location
to the correct new trusty distribution.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
