### PR TITLE
tests.linux-tools: bugfixes

### DIFF
--- a/linux-tools/crontab/control
+++ b/linux-tools/crontab/control
@@ -19,4 +19,4 @@ LOGFILE = '/tmp/autotest_cron-%s' % time.strftime('%Y-%m-%d-%H.%M.%S')
 
 tests = ['normal_cron', 'deny_cron', 'allow_cron']
 for i in range(0,3):
-    job.run_test('crontab', test = tests[i], wait_time = 65, tag = tests[i], log = LOGFILE)
+    job.run_test('linux-tools/crontab', test = tests[i], wait_time = 65, tag = tests[i], log = LOGFILE)

--- a/linux-tools/pax/control
+++ b/linux-tools/pax/control
@@ -19,4 +19,4 @@ ARCHIVE = '/tmp/archive-%s' % time.strftime('%Y-%m-%d-%H.%M.%S')
 
 tests = ['create', 'list', 'extract', 'copy']
 for i in tests:
-    job.run_test('pax', test = i, tag = i, archive = ARCHIVE)
+    job.run_test('linux-tools/pax', test = i, tag = i, archive = ARCHIVE)


### PR DESCRIPTION
linux-tools tests suffer from the following problem,
1): crontab: test does not exist
2): pax    : test does not exist

for example,
[root@localhost client]# ./autotest-local run linux-tools/crontab
10:52:56 INFO | Writing results to /root/osc/autotest/client/results/default
10:52:56 INFO | START   ----    ----    timestamp=1416538376    localtime=Nov 21 10:52:56
10:52:56 INFO |     START   crontab.normal_cron crontab.normal_cron timestamp=1416538376    localtime=Nov 21 10:52:56
10:52:56 ERROR| child process failed
10:52:56 INFO |         ERROR   crontab.normal_cron crontab.normal_cron timestamp=1416538376    localtime=Nov 21 10:52:56   crontab: test does not exist
10:52:56 INFO |     END ERROR   crontab.normal_cron crontab.normal_cron timestamp=1416538376    localtime=Nov 21 10:52:56
10:52:56 INFO |     START   crontab.deny_cron   crontab.deny_cron   timestamp=1416538376    localtime=Nov 21 10:52:56
10:52:56 ERROR| child process failed
10:52:56 INFO |         ERROR   crontab.deny_cron   crontab.deny_cron   timestamp=1416538376    localtime=Nov 21 10:52:56   crontab: test does not exist
10:52:56 INFO |     END ERROR   crontab.deny_cron   crontab.deny_cron   timestamp=1416538376    localtime=Nov 21 10:52:56
10:52:56 INFO |     START   crontab.allow_cron  crontab.allow_cron  timestamp=1416538376    localtime=Nov 21 10:52:56
10:52:56 ERROR| child process failed
10:52:56 INFO |         ERROR   crontab.allow_cron  crontab.allow_cron  timestamp=1416538376    localtime=Nov 21 10:52:56   crontab: test does not exist
10:52:56 INFO |     END ERROR   crontab.allow_cron  crontab.allow_cron  timestamp=1416538376    localtime=Nov 21 10:52:56
10:52:56 INFO | END GOOD    ----    ----    timestamp=1416538376    localtime=Nov 21 10:52:56
10:52:56 INFO | Report successfully generated at /root/osc/autotest/client/results/default/job_report.html
