### PR TITLE
Travis CI build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ git:
 
 install:
     - pip install sphinx
-    - pip install -r requirements-selftests.txt
+    - AUTOTEST_TOP_PATH="." pip install -r requirements-selftests.txt
 
 script:
     - ./runtests.py -c .nose.cfg

--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -1,5 +1,4 @@
 autotest
-sphinx
 simplejson
 MySQL-python
 inspektor==0.2


### PR DESCRIPTION
For some reason, the Travis environment doesn't set AUTOTEST_TOP_PATH
as one of the environment variables, making the setup script to
try to create /etc/autotest, causing the install to fail. Let's set
that variable and also adjust the requirements file to make the test
to go on.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>