### PR TITLE
Fixed order of -lpthread parameter

### DIFF
--- a/hackbench/hackbench.py
+++ b/hackbench/hackbench.py
@@ -22,7 +22,7 @@ class hackbench(test.test):
             cc = '$CC'
         else:
             cc = 'cc'
-        utils.system('%s -lpthread hackbench.c -o hackbench' % cc)
+        utils.system('%s hackbench.c -o hackbench -lpthread' % cc)
 
     def initialize(self):
         self.job.require_gcc()


### PR DESCRIPTION
In gcc (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609, the -lpthread does not work if used before the 'hackbench.c'. It mus be in the end, right after '-o hackbench'

Signed-off-by: Victor Aoqui (@aoqui)