### PR TITLE
Linux_tools: Fixes for Integration bugs

### DIFF
--- a/linux-tools/avahi_autoipd/avahi_autoipd.py
+++ b/linux-tools/avahi_autoipd/avahi_autoipd.py
@@ -4,6 +4,7 @@ import aexpect
 import logging
 import time
 import subprocess
+from autotest.client import utils
 from distutils.spawn import find_executable
 from autotest.client import test
 from autotest.client.shared import error

--- a/linux-tools/avahi_autoipd/control
+++ b/linux-tools/avahi_autoipd/control
@@ -7,5 +7,5 @@ TIME = 'SHORT'
 DOC = '''
 Test avahi-autoipd package
 '''
-
-job.run_test('linux-tools/avahi_autoipd')
+path = ''
+job.run_test('avahi_autoipd',test_path=path)

--- a/linux-tools/crontab/control
+++ b/linux-tools/crontab/control
@@ -15,8 +15,9 @@ Args:
 '''
 import time
 
+path = ''
 LOGFILE = '/tmp/autotest_cron-%s' % time.strftime('%Y-%m-%d-%H.%M.%S')
 
 tests = ['normal_cron', 'deny_cron', 'allow_cron']
 for i in range(0,3):
-    job.run_test('linux-tools/crontab', test = tests[i], wait_time = 65, tag = tests[i], log = LOGFILE)
+    job.run_test('crontab',test_path=path , test = tests[i], wait_time = 65, tag = tests[i], log = LOGFILE)

--- a/linux-tools/crontab/crontab.py
+++ b/linux-tools/crontab/crontab.py
@@ -1,6 +1,8 @@
 #!/bin/python
 import os
 import logging
+import shutil 
+from autotest.client import utils
 from time import sleep
 
 from autotest.client import test

--- a/linux-tools/gpgme_test/gpgme.sh
+++ b/linux-tools/gpgme_test/gpgme.sh
@@ -62,7 +62,7 @@ function run_gpgtest()
 {
    pushd $GPGME_TEST_DIR/gpg &> /dev/null
    export GNUPGHOME=`pwd`
-   sed -i 's:/builddir/build/BUILD/gpgme-[0-9]*.[0-9]*.[0-9]*/tests/gpg/pinentry:${LTPBIN%/shared}/gpgme_test/tests/gpg/pinentry:' gpg-agent.conf
+   sed -i 's:/builddir/build/BUILD/gpgme-[0-9]*.[0-9]*.[0-9]*/tests/gpg/pinentry:'${GPGME_TEST_DIR}'/gpg/pinentry:' gpg-agent.conf
    TESTS=`ls bin/*`
 
    TOTAL=`echo $TESTS | wc -w` 

--- a/linux-tools/pango/pango.sh
+++ b/linux-tools/pango/pango.sh
@@ -40,9 +40,9 @@ function tc_local_setup()
 
 	#To resolve a linker issue for 'testboundaries' test
 	version=`rpm -qv pango|cut -d"-" -f2` >$stdout 2>$stderr
-	sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./thai|${LTPBIN%/shared}/pango/modules/thai|' $modules_file
-	sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./indic|${LTPBIN%/shared}/pango/modules/indic|' $modules_file
-	sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./arabic|${LTPBIN%/shared}/pango/modules/arabic|' $modules_file
+	sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./thai|'${LTPBIN%/shared}'/pango/modules/thai|' $modules_file
+	sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./indic|'${LTPBIN%/shared}'/pango/modules/indic|' $modules_file
+	sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./arabic|'${LTPBIN%/shared}'/pango/modules/arabic|' $modules_file
 }
 
 function run_test()

--- a/linux-tools/pax/control
+++ b/linux-tools/pax/control
@@ -14,9 +14,9 @@ Creates and extracts archives using pax under /tmp/
 Args:ARCHIVE:Absolute path to the Archive 
 
 '''
-
+path = ''
 ARCHIVE = '/tmp/archive-%s' % time.strftime('%Y-%m-%d-%H.%M.%S')
 
 tests = ['create', 'list', 'extract', 'copy']
 for i in tests:
-    job.run_test('linux-tools/pax', test = i, tag = i, archive = ARCHIVE)
+    job.run_test('pax',test_path=path , test = i, tag = i, archive = ARCHIVE)

--- a/linux-tools/pax/pax.py
+++ b/linux-tools/pax/pax.py
@@ -1,7 +1,9 @@
 #!/bin/python
 import os
 import logging
-
+from autotest.client.shared  import software_manager 
+import shutil
+from autotest.client import utils
 from autotest.client import test
 from autotest.client.shared import error
 

--- a/linux-tools/pexpect_test/pexpect_test.py
+++ b/linux-tools/pexpect_test/pexpect_test.py
@@ -30,6 +30,10 @@ class pexpect_test(test.test):
         """
         try:
             os.environ["LTPBIN"] = "%s/shared" %(test_path)
+            cwd = os.getcwd()
+            os.chdir("%s/pexpect_test" %(test_path))
+            os.system("patch -p0 < pexpect-pxssh-scripts.diff")
+            os.chdir(cwd)
             ret_val = subprocess.call(test_path + '/pexpect_test' + '/pexpect.sh', shell=True)
             if ret_val != 0:
                 self.nfail += 1


### PR DESCRIPTION
crontab/pax/avahi_autoipd : Updated the test path in control file,also tests failed because import of some of the modules were missing,so added the same in .py files .
gpgme_test/pango : Fixed in .sh wrapper script(as we had used variable in sed command,but it was not handled  properly,hence the wrong path was updated in respective files )
pexpect_test : One of the test patch was not applied due to which tests were failing,hence updated pexpect_test.py  wrapper to apply patch before triggering the tests .

Signed-off-by:ramyabs<ramya@linux.vnet.ibm.com>
Tested-by:ramyabsw<ramya@linux.vnet.ibm.com>