### PR TITLE
Fixed pexpect_test to apply patch for the test to run successfully

### DIFF
--- a/linux-tools/pexpect_test/pexpect_test.py
+++ b/linux-tools/pexpect_test/pexpect_test.py
@@ -30,6 +30,10 @@ class pexpect_test(test.test):
         """
         try:
             os.environ["LTPBIN"] = "%s/shared" %(test_path)
+            cwd = os.getcwd()
+            os.chdir("%s/pexpect_test" %(test_path))
+            os.system("patch -p0 < pexpect-pxssh-scripts.diff")
+            os.chdir(cwd)
             ret_val = subprocess.call(test_path + '/pexpect_test' + '/pexpect.sh', shell=True)
             if ret_val != 0:
                 self.nfail += 1


### PR DESCRIPTION
pexpect_test : one of the test patch(pexpect-pxssh-scripts.diff) was not applied,due to which tests were failing ,hence made changes in  pexpect_test.py to apply patch before triggering the tests.

Signed-off-by:ramyabs<ramya@linux.vnet.ibm.com>
Tested-by:ramyabsw<ramya@linux.vnet.ibm.com>