### PR TITLE
Fixing acpid tests failure by adding the missing rule files in conf directory of acpid

### DIFF
--- a/linux-tools/acpid/conf/rule1
+++ b/linux-tools/acpid/conf/rule1
@@ -1,0 +1,2 @@
+event=button/power.press
+action=/bin/echo %e >> $ACTION_LOG

--- a/linux-tools/acpid/conf/rule2
+++ b/linux-tools/acpid/conf/rule2
@@ -1,0 +1,2 @@
+event=button/suspend.*
+action=/bin/echo %e >> $ACTION_LOG

--- a/linux-tools/acpid/conf/rule3
+++ b/linux-tools/acpid/conf/rule3
@@ -1,0 +1,2 @@
+event=video/lid.*
+action=/bin/echo %e >> $ACTION_LOG


### PR DESCRIPTION
acpid rules files were missing in conf directory, hence acpid failed to load rules while starting the acpid daemon. Adding these rule files addresses the issue.