### PR TITLE
Fix for gpgme and pango shell wrapper script to handle test path correctly .

### DIFF
--- a/linux-tools/gpgme_test/gpgme.sh
+++ b/linux-tools/gpgme_test/gpgme.sh
@@ -62,7 +62,7 @@ function run_gpgtest()
 {
    pushd $GPGME_TEST_DIR/gpg &> /dev/null
    export GNUPGHOME=`pwd`
-   sed -i 's:/builddir/build/BUILD/gpgme-[0-9]*.[0-9]*.[0-9]*/tests/gpg/pinentry:${LTPBIN%/shared}/gpgme_test/tests/gpg/pinentry:' gpg-agent.conf
+   sed -i 's:/builddir/build/BUILD/gpgme-[0-9]*.[0-9]*.[0-9]*/tests/gpg/pinentry:'${GPGME_TEST_DIR}'/gpg/pinentry:' gpg-agent.conf
    TESTS=`ls bin/*`
 
    TOTAL=`echo $TESTS | wc -w` 

--- a/linux-tools/pango/pango.sh
+++ b/linux-tools/pango/pango.sh
@@ -40,9 +40,9 @@ function tc_local_setup()
 
 	#To resolve a linker issue for 'testboundaries' test
 	version=`rpm -qv pango|cut -d"-" -f2` >$stdout 2>$stderr
-	sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./thai|${LTPBIN%/shared}/pango/modules/thai|' $modules_file
-	sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./indic|${LTPBIN%/shared}/pango/modules/indic|' $modules_file
-	sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./arabic|${LTPBIN%/shared}/pango/modules/arabic|' $modules_file
+        sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./thai|'${LTPBIN%/shared}'/pango/modules/thai|' $modules_file
+        sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./indic|'${LTPBIN%/shared}'/pango/modules/indic|' $modules_file
+        sed -i 's|/builddir/build/BUILD/pango-'$version'/modules/./arabic|'${LTPBIN%/shared}'/pango/modules/arabic|' $modules_file
 }
 
 function run_test()


### PR DESCRIPTION

gpgme_test/pango : Fixed in .sh wrapper script(as we had used variable in sed command ,but it was not handled  properly,hence the wrong path was updated in respective files )

Signed-off-by:ramyabs<ramya@linux.vnet.ibm.com>