### PR TITLE
Fix for avahi_autoipd ,crontab,pax path issues and import issue .

### DIFF
--- a/linux-tools/avahi_autoipd/avahi_autoipd.py
+++ b/linux-tools/avahi_autoipd/avahi_autoipd.py
@@ -4,6 +4,7 @@ import aexpect
 import logging
 import time
 import subprocess
+from autotest.client import utils
 from distutils.spawn import find_executable
 from autotest.client import test
 from autotest.client.shared import error

--- a/linux-tools/avahi_autoipd/control
+++ b/linux-tools/avahi_autoipd/control
@@ -7,5 +7,5 @@ TIME = 'SHORT'
 DOC = '''
 Test avahi-autoipd package
 '''
-
-job.run_test('linux-tools/avahi_autoipd')
+path = ''
+job.run_test('avahi_autoipd',test_path=path)

--- a/linux-tools/crontab/control
+++ b/linux-tools/crontab/control
@@ -15,8 +15,9 @@ Args:
 '''
 import time
 
+path = ''
 LOGFILE = '/tmp/autotest_cron-%s' % time.strftime('%Y-%m-%d-%H.%M.%S')
 
 tests = ['normal_cron', 'deny_cron', 'allow_cron']
 for i in range(0,3):
-    job.run_test('linux-tools/crontab', test = tests[i], wait_time = 65, tag = tests[i], log = LOGFILE)
+     job.run_test('crontab',test_path=path , test = tests[i], wait_time = 65, tag = tests[i], log = LOGFILE)

--- a/linux-tools/crontab/crontab.py
+++ b/linux-tools/crontab/crontab.py
@@ -1,8 +1,9 @@
 #!/bin/python
 import os
+import shutil
 import logging
 from time import sleep
-
+from autotest.client import utils 
 from autotest.client import test
 
 from autotest.client.shared import error

--- a/linux-tools/pax/control
+++ b/linux-tools/pax/control
@@ -14,9 +14,9 @@ Creates and extracts archives using pax under /tmp/
 Args:ARCHIVE:Absolute path to the Archive 
 
 '''
-
+path = ''
 ARCHIVE = '/tmp/archive-%s' % time.strftime('%Y-%m-%d-%H.%M.%S')
 
 tests = ['create', 'list', 'extract', 'copy']
 for i in tests:
-    job.run_test('linux-tools/pax', test = i, tag = i, archive = ARCHIVE)
+    job.run_test('pax',test_path=path , test = i, tag = i, archive = ARCHIVE)

--- a/linux-tools/pax/pax.py
+++ b/linux-tools/pax/pax.py
@@ -1,7 +1,9 @@
 #!/bin/python
 import os
+import shutil
 import logging
-
+from autotest.client.shared  import software_manager
+from autotest.client import utils
 from autotest.client import test
 from autotest.client.shared import error
 


### PR DESCRIPTION
crontab/pax/avahi_autoipd : updated the test path in control file ,and also tests failed as import of the (shutil, from autotest.client import utils etc)modules were missing ,so added the same in .py files.

Signed-off-by:ramyabs<ramya@linux.vnet.ibm.com>