### PR TITLE
Fix for policycoreutils-semodule:disable tests

### DIFF
--- a/linux-tools/avahi_autoipd/avahi_autoipd.py
+++ b/linux-tools/avahi_autoipd/avahi_autoipd.py
@@ -4,6 +4,7 @@ import aexpect
 import logging
 import time
 import subprocess
+from autotest.client import utils
 from distutils.spawn import find_executable
 from autotest.client import test
 from autotest.client.shared import error

--- a/linux-tools/avahi_autoipd/control
+++ b/linux-tools/avahi_autoipd/control
@@ -7,5 +7,5 @@ TIME = 'SHORT'
 DOC = '''
 Test avahi-autoipd package
 '''
-
-job.run_test('linux-tools/avahi_autoipd')
+path = ''
+job.run_test('avahi_autoipd',test_path=path)

--- a/linux-tools/crontab/control
+++ b/linux-tools/crontab/control
@@ -15,8 +15,9 @@ Args:
 '''
 import time
 
+path = ''
 LOGFILE = '/tmp/autotest_cron-%s' % time.strftime('%Y-%m-%d-%H.%M.%S')
 
 tests = ['normal_cron', 'deny_cron', 'allow_cron']
 for i in range(0,3):
-    job.run_test('linux-tools/crontab', test = tests[i], wait_time = 65, tag = tests[i], log = LOGFILE)
+     job.run_test('crontab',test_path=path , test = tests[i], wait_time = 65, tag = tests[i], log = LOGFILE)

--- a/linux-tools/crontab/crontab.py
+++ b/linux-tools/crontab/crontab.py
@@ -1,8 +1,9 @@
 #!/bin/python
 import os
+import shutil
 import logging
 from time import sleep
-
+from autotest.client import utils 
 from autotest.client import test
 
 from autotest.client.shared import error

--- a/linux-tools/pax/control
+++ b/linux-tools/pax/control
@@ -14,9 +14,9 @@ Creates and extracts archives using pax under /tmp/
 Args:ARCHIVE:Absolute path to the Archive 
 
 '''
-
+path = ''
 ARCHIVE = '/tmp/archive-%s' % time.strftime('%Y-%m-%d-%H.%M.%S')
 
 tests = ['create', 'list', 'extract', 'copy']
 for i in tests:
-    job.run_test('linux-tools/pax', test = i, tag = i, archive = ARCHIVE)
+    job.run_test('pax',test_path=path , test = i, tag = i, archive = ARCHIVE)

--- a/linux-tools/pax/pax.py
+++ b/linux-tools/pax/pax.py
@@ -1,7 +1,9 @@
 #!/bin/python
 import os
+import shutil
 import logging
-
+from autotest.client.shared  import software_manager
+from autotest.client import utils
 from autotest.client import test
 from autotest.client.shared import error
 

--- a/linux-tools/policycoreutils/policycoreutils.sh
+++ b/linux-tools/policycoreutils/policycoreutils.sh
@@ -63,8 +63,9 @@ function run_test()
   tc_register "semodule:disable"
   semodule -d $test_module >$stdout 2>$stderr
   tc_fail_if_bad $? "Disable failed"
-  semodule -l | grep $test_module | awk '{print $3}' >$stdout 2>$stderr
-  #grep -q Disabled $stdout
+  semodule --list=full | grep $test_module | awk '{print $4}' >$stdout 2>$stderr
+  grep -qi Disabled $stdout
+
   tc_pass_or_fail $? "Module not disabled"
 
   tc_register "semodule: enable"


### PR DESCRIPTION
Problem Description :
After Disabling the module using semodule -d,the script was trying to grep the disabled module using command  semodule -l ,which was not throwing any output to stdout hence the test failed .

Fix :
Changing  semodule -l to  semodule -list=full which will list the disabled modules on stdout and made grep command  more generic .

Signed-off-by: Ramya BS<ramyabs1@in.ibm.com>