### PR TITLE
Fixed kpartx delete partition mapping test

### DIFF
--- a/linux-tools/kpartx/kpartx.sh
+++ b/linux-tools/kpartx/kpartx.sh
@@ -86,7 +86,8 @@ function run_kpartx_tests()
 
     tc_register "Test kpartx -d"
     kpartx -d $kpartx_img >$stdout 2>$stderr
-    grep "loop deleted" $stdout | grep -q  /dev/$loopdev
+    # wait for max 10 sec to update
+    tc_wait_for_file_text $stdout "loop deleted : /dev/$loopdev"
     tc_fail_if_bad $? "kpartx -d fail1" || return
     loopdev_free=`losetup -f | cut -d '/' -f3`
     test $loopdev == $loopdev_free


### PR DESCRIPTION
Problem Description :
After executing the kpartx -d command, there was a minor delay to capture the required string hence the failure occurred.

Fix :
Modified the code to wait for 10 seconds to get the string and then continue with the execution.

Signed-off By: Kowshik Jois <kowsjois@in.ibm.com>