### PR TITLE
Fix for policycoreutils-semodule:disable tests.

### DIFF
--- a/linux-tools/policycoreutils/policycoreutils.sh
+++ b/linux-tools/policycoreutils/policycoreutils.sh
@@ -63,8 +63,8 @@ function run_test()
   tc_register "semodule:disable"
   semodule -d $test_module >$stdout 2>$stderr
   tc_fail_if_bad $? "Disable failed"
-  semodule -l | grep $test_module | awk '{print $3}' >$stdout 2>$stderr
-  #grep -q Disabled $stdout
+  semodule --list=full | grep $test_module | awk '{print $4}' >$stdout 2>$stderr
+  grep -qi Disabled $stdout
   tc_pass_or_fail $? "Module not disabled"
 
   tc_register "semodule: enable"


### PR DESCRIPTION
Problem Description :
After Disabling the module using semodule -d,the script was trying to grep the disabled module using command  semodule -l ,which was not throwing any output to stdout hence the test failed .

Fix :
changing  semodule -l to  semodule -list=full which will list the disabled modules on stdout and made grep command  more generic .

Signed-off-by: Ramya BS<ramyabs1@in.ibm.com>