### PR TITLE
Problem Description :Auditd demon are disabled at kernel on some s390…

### DIFF
--- a/linux-tools/audit/audit.sh
+++ b/linux-tools/audit/audit.sh
@@ -63,7 +63,7 @@ function tc_local_setup()
         AUDIT_VALUE=$(sed 's/.*audit=\([0-9]*\).*/\1/' $pro_cmd)
         AUDIT_DEBUG=$(sed 's/.*audit_debug=\([0-9]*\).*/\1/' $pro_cmd)
         if [[ ("$AUDIT_ENABLE" -eq "0") && ("$AUDIT_VALUE" -eq "0") && ("$AUDIT_DEBUG" -eq "0") ]]; then
-        tc_conf "Audit Services are disable at kernal please check the audit status" || exit 
+        tc_conf "Audit Services are disable at kernel please check the audit status" && exit 
         fi
         fi
 
@@ -98,7 +98,7 @@ function tc_local_setup()
 	fi
 }
 
-function tc_local_cleanup()
+function tc_restore()
 {
 	# stop our instance of audit daemon
 	service auditd stop &>/dev/null
@@ -248,4 +248,5 @@ test_basics && {
 	test_syscall_audit
 	test_audit_trace
 	test_audit_logging
+	tc_restore
 }

--- a/linux-tools/audit/audit.sh
+++ b/linux-tools/audit/audit.sh
@@ -56,7 +56,7 @@ function tc_local_setup()
 	tc_exec_or_break $required || return
         tc_check_kconfig CONFIG_AUDIT;kconfig=$?
         [ $kconfig -ne 0 ] && tc_conf "CONFIG_AUDIT  kernel configuration not enabled" && exit
-        # check if audit condtion set for s390x machine
+        # check if audit condition set for s390x machine
         grep -qi "audit" $pro_cmd
         if [ $? -eq 0 ]; then 
         AUDIT_ENABLE=$(sed 's/.*audit_enable=\([0-9]*\).*/\1/' $pro_cmd)


### PR DESCRIPTION
Fix :Fix introduced to check the audit configuration for disabled condition, print the error message and exit without test execution."tc_restore" function will do the job for restoring the audit related configuration.
Signed-off By: Anup Kumar <anupkumk@linux.vnet.ibm.com>