### PR TITLE
Traceroute: Fix test to set time delay between probes.

### DIFF
--- a/linux-tools/traceroute/traceroute.sh
+++ b/linux-tools/traceroute/traceroute.sh
@@ -88,6 +88,7 @@ function run_test()
 	# If this is the only test that passes for a system, then we can guess
 	# that there is some system in the probe path that expects some delay
 	# between probes
+	sleep 05
 	tc_register "Set time delay between probes"
 	traceroute -z 300 $dest_host|sed "1 d"|awk '{print $2}' 1>$stdout 2>$stderr
 	grep -q $dest_host $stdout


### PR DESCRIPTION
Traceroute test to set time delay between probes failed,This is happening
because of the some drop in the probe packets.Small delay needs to added
between the two tests, then these drop of probe packets doesn't exist
and we get the expected the output in the stdout.
signed-off-by: Basheer K<basheer@linux.vnet.ibm.com>