### PR TITLE
pixman : Fix for affine-bench test

### DIFF
--- a/linux-tools/pixman/pixman.sh
+++ b/linux-tools/pixman/pixman.sh
@@ -43,7 +43,7 @@ function tc_local_setup()
 function run_test()
 {
 	pushd $TESTS_DIR &>/dev/null
-	TESTS=`ls | sed '/lowlevel-blt-bench/d' | sed '/check-formats/d'`
+	TESTS=`ls | sed '/lowlevel-blt-bench/d' | sed '/check-formats/d' | sed '/affine-bench/d'`
 	TST_TOTAL=`echo $TESTS | wc -w`
 	
 	for test in $TESTS; do


### PR DESCRIPTION
Updated the wrapper-script to filter out the affine-bench test,
since benchmarking tests are not used for functional testing.

Signed-off-by: Rajashree Rajendran <rajashre@linux.vnet.ibm.com>