### PR TITLE
gtk2: Fix  gtk-query-immodules binary test case

### DIFF
--- a/linux-tools/gtk2/gtk2.sh
+++ b/linux-tools/gtk2/gtk2.sh
@@ -73,8 +73,9 @@ function run_test()
 
 function test-query-modules()
 {
-   tc_register "gtk-query-immodules-2.0-64 testing"
-   gtk-query-immodules-2.0-64 >$stdout 2>$stderr
+   [ "$HOSTTYPE" == "i686" ] && bin="gtk-query-immodules-2.0-32" || bin="gtk-query-immodules-2.0-64"
+   tc_register "$bin testing"
+   $bin >$stdout 2>$stderr
    tc_pass_or_fail $? "test failed"
 
    tc_register "gtk-update-icon-cache"

--- a/linux-tools/traceroute/traceroute.sh
+++ b/linux-tools/traceroute/traceroute.sh
@@ -88,6 +88,7 @@ function run_test()
 	# If this is the only test that passes for a system, then we can guess
 	# that there is some system in the probe path that expects some delay
 	# between probes
+	sleep 05
 	tc_register "Set time delay between probes"
 	traceroute -z 300 $dest_host|sed "1 d"|awk '{print $2}' 1>$stdout 2>$stderr
 	grep -q $dest_host $stdout


### PR DESCRIPTION
gtk2 test is failing on 32 bit arch, as testcase is using gtk-query-immodules 64bit binary.
Modified the testcase to pick the binary depends on architecture.

signed-off-by : Basheer K  <basheer@linux.vnet.ibm.com>
