### PR TITLE
.travis.yml: Install setuptools before sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ git:
     submodules: false
 
 install:
+    - pip install setuptools
     - pip install sphinx
     - AUTOTEST_TOP_PATH="." pip install -r requirements-selftests.txt
 


### PR DESCRIPTION
Recent versions of sphinx require setuptools, let's add
them to the .travis.yml file.

This should fix a CI problem in autotest-client-tests.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>