### PR TITLE
aio_dio_bugs: add test case for CVE-2016-10044

### DIFF
--- a/aio_dio_bugs/aio_dio_bugs.py
+++ b/aio_dio_bugs/aio_dio_bugs.py
@@ -10,6 +10,7 @@ tests = [["aio-dio-invalidate-failure", "poo"],
          ["aio-free-ring-with-bogus-nr-pages", ""],
          ["aio-io-setup-with-nonwritable-context-pointer", ""],
          ["aio-dio-extend-stat", "file"],
+         ["aio-cve-2016-10044", ""],
          ]
 name = 0
 arglist = 1

--- a/aio_dio_bugs/src/Makefile
+++ b/aio_dio_bugs/src/Makefile
@@ -4,7 +4,8 @@ CFLAGS=-W -Wall
 
 TESTS=aio-dio-invalidate-failure aio-dio-subblock-eof-read \
       aio-free-ring-with-bogus-nr-pages \
-      aio-io-setup-with-nonwritable-context-pointer aio-dio-extend-stat
+      aio-io-setup-with-nonwritable-context-pointer aio-dio-extend-stat \
+      aio-cve-2016-10044
 
 all: $(TESTS)
 
@@ -22,3 +23,6 @@ aio-io-setup-with-nonwritable-context-pointer: aio-io-setup-with-nonwritable-con
 
 aio-dio-extend-stat: aio-dio-extend-stat.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -lpthread -o $@ $^
+
+aio-cve-2016-10044: aio-cve-2016-10044.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^

--- a/aio_dio_bugs/src/aio-cve-2016-10044.c
+++ b/aio_dio_bugs/src/aio-cve-2016-10044.c
@@ -1,0 +1,76 @@
+/*
+ * Code taken from the commit message in the patch for CVE-2016-10044
+ * 22f6b4d34fcf039c63a94e7670e0da24f8575a5a
+ * Original author: Jann Horn <jann@thejh.net>
+ * Changed by Po-Hsu Lin <po-hsu.lin@canonical.com>
+ * Modified to add it into the autotest framework.
+ *
+ * This CVE issue will let do_mmap() implicitly make AIO memory mappings
+ * executable if the READ_IMPLIES_EXEC personality flag is set.
+ * Therefore in the output, "rw-s" is good, "rwxs" is bad.
+ */
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <sys/personality.h>
+#include <linux/aio_abi.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <string.h>
+
+#define exception(msg){\
+    perror(msg);\
+    exit(EXIT_FAILURE);\
+}
+int main(void) {
+    char fname[512];
+    char buf[512];
+    int ret = EXIT_SUCCESS;
+    FILE *fptr;
+    personality(READ_IMPLIES_EXEC);
+    aio_context_t ctx = 0;
+    if (syscall(__NR_io_setup, 1, &ctx)) {
+        exception("io_setup");
+    }
+    sprintf(fname, "/proc/%d/maps", (int)getpid());
+    if ((fptr = fopen(fname, "r")) == NULL) {
+        exception(fname);
+    }
+    else {
+        while (fgets(buf, sizeof(buf), fptr) != NULL) {
+            unsigned long vm_start;
+            unsigned long vm_end;
+            char rwxs[4] = {0};
+            unsigned long long pgoff;
+            int major, minor;
+            unsigned long ino;
+            char proc[6] = {0};
+            int n;
+            n = sscanf(buf, "%lx-%lx %4s %llx %x:%x %lu %6s",
+                       &vm_start,
+                       &vm_end,
+                       rwxs,
+                       &pgoff,
+                       &major, &minor,
+                       &ino,
+                       proc);
+            if (n < 7) {
+                fprintf(stderr, "unexpected line: %s\n", buf);
+                continue;
+            }
+            if (strcmp("/[aio]", proc) == 0) {
+                printf("Permission for /[aio] is %s, expecting rw-s\n", rwxs);
+                if (strcmp("rw-s", rwxs) != 0) {
+                    fprintf(stderr, "FAILED. Vulnerable to CVE-2016-10044\n");
+                    ret = EXIT_FAILURE;
+                }
+                else {
+                    printf("PASSED\n");
+                }
+                break;
+            }
+        };
+        fclose(fptr);
+    };
+    return ret;
+};


### PR DESCRIPTION
This test will check if AIO memory mappings is executable for CVE-2016-10044,
code taken from the commit message in the patch for that CVE (22f6b4d3).
Original author: Jann Horn <jann@thejh.net>
Changed by Po-Hsu Lin to add it into the autotest framework.

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>