### PR TITLE
aio_dio_bugs: fix string overflow for aio-cve-2017-10044

### DIFF
--- a/aio_dio_bugs/src/aio-cve-2016-10044.c
+++ b/aio_dio_bugs/src/aio-cve-2016-10044.c
@@ -10,6 +10,7 @@
  * Therefore in the output, "rw-s" is good, "rwxs" is bad.
  */
 #define _GNU_SOURCE
+#include <inttypes.h>
 #include <unistd.h>
 #include <sys/personality.h>
 #include <linux/aio_abi.h>
@@ -38,15 +39,15 @@ int main(void) {
     }
     else {
         while (fgets(buf, sizeof(buf), fptr) != NULL) {
-            unsigned long vm_start;
-            unsigned long vm_end;
-            char rwxs[4] = {0};
-            unsigned long long pgoff;
-            int major, minor;
-            unsigned long ino;
-            char proc[6] = {0};
-            int n;
-            n = sscanf(buf, "%lx-%lx %4s %llx %x:%x %lu %6s",
+            uint64_t vm_start;
+            uint64_t vm_end;
+            char rwxs[5] = {0};
+            uint64_t pgoff;
+            int32_t major, minor;
+            uint32_t ino;
+            char proc[7] = {0};
+            int32_t n;
+            n = sscanf(buf, "%"PRIx64"-%"PRIx64" %4s %"PRIx64" %x:%x %u %6s",
                        &vm_start,
                        &vm_end,
                        rwxs,


### PR DESCRIPTION
It was found that this test case will not work as expected on i386 systems.
Which will print something like:

Permission for /[aio] is rw-s/[aio], expecting rw-s
FAILED. Vulnerable to CVE-2016-10044

This issue was caused by the insufficient size of the char array and the size
difference of a long integer on 32/64 bits system. Fix it by increasing the
array size and use inttypes.h to secure the variable size.

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>