### PR TITLE
.travis.yml: Pin Sphinx version on 1.4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ git:
 
 install:
     - pip install setuptools
-    - pip install sphinx
+    - pip install sphinx==1.4.9
     - AUTOTEST_TOP_PATH="." pip install -r requirements-selftests.txt
 
 script:


### PR DESCRIPTION
It's the last one that actually works on python 2.6, so
let's pin that version down.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>