### PR TITLE
Modifed existing code to work on Ubuntu.

### DIFF
--- a/linux-tools/ltrace/ltrace.sh
+++ b/linux-tools/ltrace/ltrace.sh
@@ -137,7 +137,12 @@ function test07()
 	tc_register	"ltrace -L -S command"
 	ltrace -L -S ./ltracetest1 &>$stdout
 	tc_fail_if_bad $? "ltrace -L -S command failed" || return	
-	grep -q "open@SYS" $stdout
+	grep -i "ubuntu" /etc/*-release >/dev/null 2>&1
+        if [ $? -eq 0 ];then
+                grep -q "SYS_open" $stdout
+        else
+                grep -q "open@SYS" $stdout
+        fi
 	tc_pass_or_fail $? "ltrace -L -S command failed"
 }
 

--- a/linux-tools/mlocate/locate.sh
+++ b/linux-tools/mlocate/locate.sh
@@ -56,14 +56,25 @@ function tc_local_setup()
         touch $locate_this
 
 	# temporarily stop cron process
-	tc_service_stop_and_wait crond
+	grep -i "ubuntu" /etc/*-release >/dev/null 2>&1
+        rc=$?
+        if [ $rc -eq 0 ];then
+                tc_service_stop_and_wait cron
+        else
+                tc_service_stop_and_wait crond
+        fi
 	cron_stopped="yes"
 	return 0
 }
 
 function tc_local_cleanup()
 {
-        [ "$cron_stopped" = "yes" ] && tc_service_start_and_wait crond
+	if [ $rc -eq 0 ];then
+                [ "$cron_stopped" = "yes" ] && tc_service_start_and_wait cron
+        else
+                [ "$cron_stopped" = "yes" ] && tc_service_start_and_wait crond
+        fi
+
 }
 
 #


### PR DESCRIPTION
ltrace - In Ubuntu, ltrace -L -S output was different.
Modified script to grep for SYS_open instead of open@SYS

mlocate - crond service in Ubuntu is cron service.
Updated the wrapper to check for cron instead of crond

Signed-off-by: Rajashree Rajendran <rajashre@linux.vnet.ibm.com>