### PR TITLE
hwclock: check the hwclock until --set operation finishes

### DIFF
--- a/hwclock/hwclock.py
+++ b/hwclock/hwclock.py
@@ -14,7 +14,7 @@ class hwclock(test.test):
         effect in the system.
         """
         logging.info('Setting hwclock to 2/2/80 03:04:00')
-        utils.system('/sbin/hwclock --set --date "2/2/80 03:04:00"')
+        utils.system_output('/sbin/hwclock --set --date "2/2/80 03:04:00"', retain_output=True)
         date = utils.system_output('LC_ALL=C /sbin/hwclock')
         if not re.match('Sat *Feb *2 *03:04:.. 1980', date):
             raise error.TestFail("Failed to set hwclock back to the eighties. "


### PR DESCRIPTION
On some system, a HP ProLiant m400 Server in my case, this hwclock --set
operation will take about 0.5 - 1 second to finish. So if we fork another
subprocess immediately to check the output from hwclock, it will get the
timestamp before this modification.

Use utils.system_output() to wait for the hwclock --set command to finish.

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>