### PR TITLE
[PATCH] Fix for pam_krb5 authentication and make failure

### DIFF
--- a/linux-tools/pam_krb5/pam_krb5.py
+++ b/linux-tools/pam_krb5/pam_krb5.py
@@ -26,6 +26,9 @@ class pam_krb5(test.test):
         if not sm.check_installed('gcc'):
             logging.debug("gcc missing - trying to install")
             sm.install('gcc')
+        if not sm.check_installed('pam-devel'):
+            logging.debug("pam-devel missing - trying to install")
+            sm.install('pam-devel')
         ret_val = subprocess.Popen(['make', 'all'], cwd="%s/pam_krb5" %(test_path))
         ret_val.communicate()
         if ret_val.returncode != 0:

--- a/linux-tools/pam_krb5/pam_krb5.sh
+++ b/linux-tools/pam_krb5/pam_krb5.sh
@@ -280,6 +280,11 @@ tc_local_setup()
 	[ "$RANDOM_PID" != "0" ] && kill -9 $RANDOM_PID 2>/dev/null
 	# If we are here, then KRB5 has started and RANDOM_PID is killed.
 	RANDOM_PID=0
+
+        if [ -e /etc/krb5.keytab ]; then
+            keytab=1
+            mv /etc/krb5.keytab /etc/krb5.keytab.bckup
+        fi
 }
 
 function tc_local_cleanup()
@@ -287,6 +292,10 @@ function tc_local_cleanup()
 	tc_info "Stoping krb5 servers"
 	kdcstop
 	[ "$RANDOM_PID" != "0" ] && kill -9 $RANDOM_PID 2>/dev/null
+
+        if [ $keytab -eq 1 ]; then
+            mv /etc/krb5.keytab.bckup /etc/krb5.keytab
+        fi
 }
 
 test_password()


### PR DESCRIPTION
Issue 1: From the analysis, Tests in pam_krb5 needs tools/pam_harness.c file to be compiled to generate pam_harness binary which requires pam-devel package to be installed. so added a check and installation for pam-devel in python wrapper.

Issue 2: From the analysis, the issue raises with error Server not found in Kerberos database(KDC).
All Kerberos server machines uses credential cache (or “ccache”)  that holds Kerberos credentials or  keytab file (by default /etc/krb5.keytab) which contains key value pairs for authentication purpose.
Here in the test_password test it looks for the default keytab file (/etc/krb5.keytab) to get TGT (ticket to access the service) and the test fails with "server not found in kerberos database(KDC).
Since the kerberos is configured to use the temporary cache file created to authenticate the user, this authentication will be successful with the temporary cache file created for the session.

Hence if the default /etc/krb5.keytab file is not available, then the kerberos uses temporary cache to authenticate the user.

Signed-off By: Kowshik Jois <kowsjois@in.ibm.com>