### PR TITLE
libnfsidmap: Fix the testcase to remove nfs-secure-server

### DIFF
--- a/linux-tools/libnfsidmap/libnfsidmap.sh
+++ b/linux-tools/libnfsidmap/libnfsidmap.sh
@@ -219,7 +219,6 @@ function tc_local_cleanup()
         # unmount the NFS directory
         tc_service_stop_and_wait nfs
         tc_service_stop_and_wait nfs-secure
-	tc_service_stop_and_wait nfs-secure-server
 	umount /mnt
         umount /mnt/NFS_PARTITION
         rm -f $TESTDIR/ext3.img


### PR DESCRIPTION
nfs-secure-server service is removed from nfs-utils RPM.
So remove this from testcase as well. Tests/functionality works fine with this change.

Signed-off-by: Athira Rajeev <atrajeev@linux.vnet.ibm.com>